### PR TITLE
initialize PakExporter::Data to nullptr

### DIFF
--- a/source/KAO2_PAK/PakExporter.cpp
+++ b/source/KAO2_PAK/PakExporter.cpp
@@ -14,6 +14,7 @@ PakExporter::PakExporter(char* pak, char* directory, bool log)
     LanguagesCount = 0;
     std::memset(Languages, 0x00, sizeof(Languages));
     std::memset(BlockSizes, 0x00, sizeof(BlockSizes));
+    Data = nullptr;
 
     /* Save paths */
 

--- a/source/KAO2_PAK/PakImporter.cpp
+++ b/source/KAO2_PAK/PakImporter.cpp
@@ -14,6 +14,7 @@ PakImporter::PakImporter(char* log)
     std::memset(Languages, 0x00, sizeof(Languages));
     std::memset(BlockSizes, 0x00, sizeof(BlockSizes));
     std::memset(ItemsCount, 0x00, sizeof(ItemsCount));
+    Data = nullptr;
 
     /* Save file path */
 


### PR DESCRIPTION
fixes a possible null pointer dereference